### PR TITLE
Remove workaround for handling `ipv4.gateway`

### DIFF
--- a/lib/puppet/provider/lxc_interface/interface.rb
+++ b/lib/puppet/provider/lxc_interface/interface.rb
@@ -217,12 +217,10 @@ Puppet::Type.type(:lxc_interface).provide(:interface) do
     end
   end
 
-  # TODO: There is an inconsistency in liblxc, https://github.com/lxc/lxc/pull/337
-  # thus, ipv4_gateway should detect version and work properly if the PR gets merged in.
   def ipv4_gateway
     begin
       define_container
-      @container.config_item("lxc.network.#{@resource[:index]}.ipv4_gateway")
+      @container.config_item("lxc.network.#{@resource[:index]}.ipv4.gateway")
     rescue LXC::Error
       ""
     end
@@ -231,7 +229,6 @@ Puppet::Type.type(:lxc_interface).provide(:interface) do
   def ipv4_gateway=(value)
     begin
       define_container
-      @container.clear_config_item("lxc.network.#{@resource[:index]}.ipv4_gateway")
       @container.set_config_item("lxc.network.#{@resource[:index]}.ipv4.gateway",value)
       @container.save_config
       restart if @resource[:restart]

--- a/spec/unit/provider/interface_spec.rb
+++ b/spec/unit/provider/interface_spec.rb
@@ -174,11 +174,11 @@ describe Puppet::Type.type(:lxc_interface).provider(:interface), 'basic interfac
 
   describe '#ipv4_gateway' do
     it 'will return 192.168.1.254' do
-      @provider.container.stubs(:config_item).with('lxc.network.1.ipv4_gateway').returns('192.168.1.254')
+      @provider.container.stubs(:config_item).with('lxc.network.1.ipv4.gateway').returns('192.168.1.254')
       @provider.send(:ipv4_gateway).should == '192.168.1.254'
     end
     it 'will return true when the setter successfully changes the value' do
-      @provider.container.stubs(:clear_config_item).with('lxc.network.1.ipv4_gateway')
+      @provider.container.stubs(:clear_config_item).with('lxc.network.1.ipv4.gateway')
       @provider.container.stubs(:set_config_item).with('lxc.network.1.ipv4.gateway','192.168.1.253')
       @provider.container.stubs(:save_config)
       @provider.send(:ipv4_gateway=,'192.168.1.253').should == true


### PR DESCRIPTION
On Ubuntu Trusty, using `ipv4.gateway' works fine:

```ruby
c = LXC::Container.new('vpn') # => #<LXC::Container:0x0000000203d408>
c.config_item("lxc.network.0.ipv4.gateway") # => "10.0.0.1"
c.set_config_item("lxc.network.0.ipv4.gateway", '10.0.0.2') # => #<LXC::Container:0x0000000203d408>
c.config_item("lxc.network.0.ipv4.gateway") # => "10.0.0.2"
c.save_config # => #<LXC::Container:0x00000001e49bb0>
```

```bash
root@ubuntu:~# grep ipv4 /var/lib/lxc/vpn/config
lxc.network.ipv4.gateway = 10.0.0.2
lxc.network.ipv4 = 10.0.0.4/24
```