### PR TITLE
use assert_private instead of deprecated private

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,6 +5,6 @@ fixtures:
       ref: "origin/1.7.x"
     stdlib:
       repo: "https://github.com/puppetlabs/puppetlabs-stdlib"
-      ref: "origin/4.4.x"
+      ref: "origin/4.6.x"
   symlinks:
       lxc: "#{source_dir}"

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -12,7 +12,7 @@
 #
 class lxc::install inherits lxc::params {
 
-  private()
+  assert_private()
 
   $lxc_ruby_bindings_deps = $lxc::lxc_ruby_bindings_provider ? {
     gem     => $lxc::params::lxc_ruby_bindings_gem_deps,

--- a/manifests/networking/containers.pp
+++ b/manifests/networking/containers.pp
@@ -12,7 +12,7 @@
 #
 class lxc::networking::containers inherits lxc::params {
 
-  private()
+  assert_private()
 
   if empty($lxc::lxc_networking_device_link) and
     empty($lxc::lxc_networking_type) {

--- a/manifests/networking/nat.pp
+++ b/manifests/networking/nat.pp
@@ -12,7 +12,7 @@
 #
 class lxc::networking::nat inherits lxc::params {
 
-  private()
+  assert_private()
 
   case $lxc::lxc_networking_nat_enable {
     true: {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -12,7 +12,7 @@
 #
 class lxc::service {
 
-  private()
+  assert_private()
 
   service { $lxc::lxc_lxc_service:
     ensure => $lxc::lxc_lxc_service_ensure,

--- a/manifests/sources/precise.pp
+++ b/manifests/sources/precise.pp
@@ -12,7 +12,7 @@
 #
 class lxc::sources::precise {
 
-  private()
+  assert_private()
 
   contain 'apt'
 

--- a/metadata.json
+++ b/metadata.json
@@ -30,7 +30,7 @@
     },
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 3.2.0 < 5.0.0"
+      "version_requirement": ">= 4.6.0 < 5.0.0"
     }
   ]
 }


### PR DESCRIPTION
Using `private()` is [deprecated](https://github.com/puppetlabs/puppetlabs-stdlib/blob/master/lib/puppet/parser/functions/private.rb#L11), `assert_private()` should be used instead.