### PR TITLE
Allow configuration of lxc_ruby_bindings_gem_deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ For more information about LXC visit: [linuxcontainers.org](https://linuxcontain
  * lxc_ruby_bindings_package
   Name for the LXC ruby bindings. Defaults to ruby-lxc.
 
+ * lxc_ruby_bindings_gem_deps
+  Name for the LXC ruby bindings gem dependencies. Defaults are distribution and release specific.
+
  * lxc_ruby_bindings_version
   Version for LXC ruby bindings. Defaults to 1.2.0.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -97,6 +97,7 @@
 class lxc (
   $lxc_ruby_bindings_provider        = $lxc::params::lxc_ruby_bindings_provider,
   $lxc_ruby_bindings_package         = $lxc::params::lxc_ruby_bindings_package,
+  $lxc_ruby_bindings_gem_deps        = $lxc::params::lxc_ruby_bindings_gem_deps,
   $lxc_ruby_bindings_version         = $lxc::params::lxc_ruby_bindings_version,
   $lxc_lxc_package                   = $lxc::params::lxc_lxc_package,
   $lxc_lxc_version                   = $lxc::params::lxc_lxc_version,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,6 +10,9 @@
 # [*lxc_ruby_bindings_package*]
 #   Name for the LXC ruby bindings. Defaults to ruby-lxc.
 #
+# [*lxc_ruby_bindings_gem_deps*]
+#   Name for the LXC ruby bindings gem dependencies. Defaults are distribution and release specific.
+#
 # [*lxc_ruby_bindings_version*]
 #   Version for LXC ruby bindings. Defaults to 1.2.0.
 #

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -15,7 +15,7 @@ class lxc::install inherits lxc::params {
   assert_private()
 
   $lxc_ruby_bindings_deps = $lxc::lxc_ruby_bindings_provider ? {
-    gem     => $lxc::params::lxc_ruby_bindings_gem_deps,
+    gem     => $lxc::lxc_ruby_bindings_gem_deps,
     default => ['']
   }
 


### PR DESCRIPTION
This PR allows the user to set the ruby binding gem dependencies like all the other parameters.
