### PR TITLE
CentOS compatibility

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -12,7 +12,7 @@
 #
 class lxc::install inherits lxc::params {
 
-  private()
+  #private()
 
   $lxc_ruby_bindings_deps = $lxc::lxc_ruby_bindings_provider ? {
     gem     => $lxc::params::lxc_ruby_bindings_gem_deps,

--- a/manifests/networking/containers.pp
+++ b/manifests/networking/containers.pp
@@ -12,7 +12,7 @@
 #
 class lxc::networking::containers inherits lxc::params {
 
-  private()
+#  private()
 
   if empty($lxc::lxc_networking_device_link) and
     empty($lxc::lxc_networking_type) {

--- a/manifests/networking/nat.pp
+++ b/manifests/networking/nat.pp
@@ -12,7 +12,7 @@
 #
 class lxc::networking::nat inherits lxc::params {
 
-  private()
+#  private()
 
   case $lxc::lxc_networking_nat_enable {
     true: {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -31,11 +31,13 @@ class lxc::params {
         }
       }
     }
-    default: {
-      #fail("${::operatingsystem} is not supported by ${module_name} module.")
+    'RedHat', 'CentOS': {
       $lxc_ruby_bindings_gem_deps = [
         'gcc', 'lxc-devel'
       ]
+    }
+    default: {
+      fail("${::operatingsystem} is not supported by ${module_name} module.")
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,7 +32,10 @@ class lxc::params {
       }
     }
     default: {
-      fail("${::operatingsystem} is not supported by ${module_name} module.")
+      #fail("${::operatingsystem} is not supported by ${module_name} module.")
+      $lxc_ruby_bindings_gem_deps = [
+        'gcc', 'lxc-devel'
+      ]
     }
   }
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -12,7 +12,7 @@
 #
 class lxc::service {
 
-  private()
+ # private()
 
   service { $lxc::lxc_lxc_service:
     ensure => $lxc::lxc_lxc_service_ensure,

--- a/manifests/sources/precise.pp
+++ b/manifests/sources/precise.pp
@@ -12,7 +12,7 @@
 #
 class lxc::sources::precise {
 
-  private()
+#  private()
 
   contain 'apt'
 


### PR DESCRIPTION
For the compatibility with Puppet 4.x , I needed to remove the `private()` calls.

Tested on CentOS 7.1

Remaining issue noted: running multiple times an extra empty ipv4 entry appears in the container `config` file, e.g.:
```
lxc.network.0.ipv4 =
lxc.network.0.ipv4 = 172.17.18.1/24
```

Not sure if it is a bug in the upstream.